### PR TITLE
Add option to disable warnings as errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(KIERO_INCLUDE_OPENGL "Enable support for OpenGL" OFF)
 option(KIERO_INCLUDE_VULKAN "Enable support for Vulkan" OFF)
 option(KIERO_USE_MINHOOK "Enables \"kiero::bind\" as a wrapper around MinHook" OFF)
 option(KIERO_MINHOOK_EXTERNAL "Use an externally provided MinHook instead of the bundled" OFF)
+option(KIERO_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 
 project(kiero VERSION 1.2.12)
 
@@ -21,21 +22,23 @@ set_target_properties(kiero PROPERTIES
     CXX_STANDARD_REQUIRED ON
 )
 
-if (MSVC)
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        target_compile_options(kiero PRIVATE
-            /clang:-Wall
-            /clang:-Wextra
-            /clang:-Wcast-align
-            /clang:-Wconversion
-            /clang:-Wsign-conversion
-            /clang:-Wold-style-cast
-            /clang:-Wimplicit-fallthrough
-        )
+if (KIERO_WARNINGS_AS_ERRORS)
+    if (MSVC)
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            target_compile_options(kiero PRIVATE
+                /clang:-Wall
+                /clang:-Wextra
+                /clang:-Wcast-align
+                /clang:-Wconversion
+                /clang:-Wsign-conversion
+                /clang:-Wold-style-cast
+                /clang:-Wimplicit-fallthrough
+            )
+        endif()
+        target_compile_options(kiero PRIVATE /WX /W4)
+    else()
+        message(WARNING "Non Microsoft compatible compiler detected")
     endif()
-    target_compile_options(kiero PRIVATE /WX /W4)
-else()
-    message(WARNING "Non Microsoft compatible compiler detected")
 endif()
 
 if (NOT (KIERO_INCLUDE_D3D9 OR KIERO_INCLUDE_D3D10 OR KIERO_INCLUDE_D3D11 OR KIERO_INCLUDE_D3D12 OR KIERO_INCLUDE_OPENGL OR KIERO_INCLUDE_VULKAN))


### PR DESCRIPTION
Wehn not using MinHook with Kiero, the _index variable on like 133 of kiero.cpp raises a warning, which is then treated as an error. This adds an option to disable this.